### PR TITLE
Add ozone simulation model example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# test
-Testing w/ Codex
+# Ozone Simulation
+
+This repository contains a simple Python implementation to estimate ozone released from major roadways in the Salt Lake City valley. The example uses a coarse 3D grid and simple advection/diffusion scheme implemented without external dependencies.
+
+## Files
+
+- `ozone_model.py` – minimal ozone transport model.
+- `simulate.py` – runs a 24‑hour example simulation with basic road sources.
+
+## Running the example
+
+```bash
+python3 simulate.py
+```
+
+The script prints the total ozone in the domain at each hourly step.

--- a/ozone_model.py
+++ b/ozone_model.py
@@ -1,0 +1,98 @@
+from dataclasses import dataclass, field
+from typing import Callable, List, Tuple
+import math
+
+# Simple 3D ozone model using finite difference scheme
+
+@dataclass
+class RoadSource:
+    start: Tuple[float, float]
+    end: Tuple[float, float]
+    rate_func: Callable[[float], float]
+
+    def cells(self, dx: float, dy: float) -> List[Tuple[int, int]]:
+        """Return grid cells along the road"""
+        x0, y0 = self.start
+        x1, y1 = self.end
+        length_x = x1 - x0
+        length_y = y1 - y0
+        steps = int(max(abs(length_x / dx), abs(length_y / dy))) + 1
+        cells = []
+        for s in range(steps + 1):
+            t = s / steps
+            xi = x0 + t * length_x
+            yi = y0 + t * length_y
+            i = int(xi / dx)
+            j = int(yi / dy)
+            cells.append((i, j))
+        return list(dict.fromkeys(cells))
+
+@dataclass
+class OzoneModel:
+    north_south: Tuple[float, float]
+    west_east: Tuple[float, float]
+    top_altitude: float = 2000.0
+    dx: float = 1000.0
+    dy: float = 1000.0
+    dz: float = 100.0
+    u: float = 1.0  # north-south wind velocity
+    v: float = 0.0  # west-east wind velocity
+    w: float = 0.1  # vertical velocity
+    D: float = 0.1  # diffusion coefficient
+    top_open: bool = True
+
+    grid: List[List[List[float]]] = field(init=False)
+    sources: List[Tuple[RoadSource, List[Tuple[int, int]]]] = field(default_factory=list)
+    current_time: float = 0.0
+
+    def __post_init__(self):
+        self.nx = int((self.north_south[1] - self.north_south[0]) / self.dx) + 1
+        self.ny = int((self.west_east[1] - self.west_east[0]) / self.dy) + 1
+        self.nz = int(self.top_altitude / self.dz) + 1
+        self.grid = [[[0.0 for _ in range(self.nz)] for _ in range(self.ny)] for _ in range(self.nx)]
+
+    def add_road_source(self, road: RoadSource):
+        cells = road.cells(self.dx, self.dy)
+        self.sources.append((road, cells))
+
+    def step(self, dt: float):
+        new_grid = [[[0.0 for _ in range(self.nz)] for _ in range(self.ny)] for _ in range(self.nx)]
+        for i in range(self.nx):
+            for j in range(self.ny):
+                for k in range(self.nz):
+                    c = self.grid[i][j][k]
+                    # Advection (upwind difference)
+                    if i > 0:
+                        c -= dt * self.u * (c - self.grid[i - 1][j][k]) / self.dx
+                    if j > 0:
+                        c -= dt * self.v * (c - self.grid[i][j - 1][k]) / self.dy
+                    if k > 0:
+                        c -= dt * self.w * (c - self.grid[i][j][k - 1]) / self.dz
+                    # Diffusion (simple)
+                    if i > 0 and i < self.nx - 1:
+                        c += dt * self.D * (self.grid[i + 1][j][k] - 2 * c + self.grid[i - 1][j][k]) / (self.dx ** 2)
+                    if j > 0 and j < self.ny - 1:
+                        c += dt * self.D * (self.grid[i][j + 1][k] - 2 * c + self.grid[i][j - 1][k]) / (self.dy ** 2)
+                    if k > 0 and k < self.nz - 1:
+                        c += dt * self.D * (self.grid[i][j][k + 1] - 2 * c + self.grid[i][j][k - 1]) / (self.dz ** 2)
+                    new_grid[i][j][k] = c
+
+        # Apply sources at ground level
+        for road, cells in self.sources:
+            rate = road.rate_func(self.current_time)
+            for i, j in cells:
+                if 0 <= i < self.nx and 0 <= j < self.ny:
+                    new_grid[i][j][0] += rate * dt
+
+        # Apply top boundary
+        if self.top_open:
+            for i in range(self.nx):
+                for j in range(self.ny):
+                    new_grid[i][j][self.nz - 1] = 0.0
+
+        self.grid = new_grid
+        self.current_time += dt
+
+    def total_ozone(self) -> float:
+        return sum(sum(sum(layer for layer in row) for row in plane) for plane in self.grid)
+

--- a/simulate.py
+++ b/simulate.py
@@ -1,0 +1,34 @@
+from ozone_model import OzoneModel, RoadSource
+
+# Boundaries for SLC area (arbitrary units)
+# north_south: 0 at north (2300 N) to 16900 at south (14600 S)
+# west_east: 0 at west (Route 85) to 20000 at east (Wasatch)
+model = OzoneModel(north_south=(0, 16900), west_east=(0, 20000))
+
+# Example emission rate functions
+
+def rush_hour_rate(t: float) -> float:
+    """Higher emission during rush hour (7-9am, 4-6pm)"""
+    hour = t % 24
+    if 7 <= hour < 9 or 16 <= hour < 18:
+        return 5.0
+    if 0 <= hour < 5:
+        return 0.5
+    return 1.0
+
+# Add major roads (simplified as straight lines)
+# I-15 runs north-south through center of valley
+model.add_road_source(RoadSource(start=(0, 10000), end=(16900, 10000), rate_func=rush_hour_rate))
+# I-215 partial loop (approx)
+model.add_road_source(RoadSource(start=(5000, 18000), end=(15000, 18000), rate_func=rush_hour_rate))
+# I-80 east-west
+model.add_road_source(RoadSource(start=(8000, 0), end=(8000, 20000), rate_func=rush_hour_rate))
+
+# Simple simulation
+if __name__ == "__main__":
+    steps = 24
+    dt = 1.0  # hour
+    for s in range(steps):
+        model.step(dt)
+        total = model.total_ozone()
+        print(f"Hour {s+1}: total ozone={total:.2f}")


### PR DESCRIPTION
## Summary
- add `ozone_model.py` implementing a small 3D ozone transport model
- add `simulate.py` to run a 24 hour sample over Salt Lake City
- update README with instructions

## Testing
- `python3 simulate.py > /tmp/out && tail -n 3 /tmp/out`

------
https://chatgpt.com/codex/tasks/task_e_68879d41eb3c8328b69046be396b025f