### PR TITLE
Add parser for ozone input file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # test
-Testing w/ Codex
+
+This repository includes a simple parser for an ozone model input file.
+
+## Usage
+
+Create an input file named `input.ozone` with sections beginning with a `#`.
+Example:
+
+```
+#TIME
+07    start time
+12.   end time
+
+#TOPBOUNDARY
+100
+```
+
+Run the parser:
+
+```
+python parser.py input.ozone
+```

--- a/input.ozone
+++ b/input.ozone
@@ -1,0 +1,6 @@
+#TIME
+07    start time
+12.   end time
+
+#TOPBOUNDARY
+100

--- a/parser.py
+++ b/parser.py
@@ -1,0 +1,44 @@
+import re
+from typing import Dict, List, Any
+
+
+def parse_input(filename: str) -> Dict[str, Any]:
+    data: Dict[str, Any] = {}
+    current_section = None
+    with open(filename, 'r') as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith('#'):
+                current_section = line[1:].strip().upper()
+                data[current_section] = []
+                continue
+            if current_section is None:
+                continue
+            # Split off comment after the value
+            value_str = re.split(r"\s+", line, 1)[0]
+            try:
+                # try int first then float
+                if '.' in value_str:
+                    value = float(value_str)
+                else:
+                    value = int(value_str)
+            except ValueError:
+                continue
+            data[current_section].append(value)
+    return data
+
+
+def main():
+    import sys
+    if len(sys.argv) < 2:
+        print("Usage: python parser.py <input_file>")
+        return
+    result = parse_input(sys.argv[1])
+    for section, values in result.items():
+        print(f"{section}: {values}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test_parser.py
+++ b/test_parser.py
@@ -1,0 +1,13 @@
+import unittest
+from parser import parse_input
+
+class TestParser(unittest.TestCase):
+    def test_parse_time_and_boundary(self):
+        data = parse_input('input.ozone')
+        self.assertIn('TIME', data)
+        self.assertEqual(data['TIME'], [7, 12.0])
+        self.assertIn('TOPBOUNDARY', data)
+        self.assertEqual(data['TOPBOUNDARY'], [100])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add example input file `input.ozone`
- implement `parser.py` to read sections beginning with `#`
- document usage in README
- add unit test `test_parser.py`

## Testing
- `python -m unittest -v`

------
https://chatgpt.com/codex/tasks/task_e_6887a59acac48328b014e414a3d4ed62