### PR TITLE
Add basic map visualization for Salt Lake City valley

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Ozone Simulation
 
-This repository contains a simple Python implementation to estimate ozone released from major roadways in the Salt Lake City valley. The example uses a coarse 3D grid and simple advection/diffusion scheme implemented without external dependencies.
+This repository contains a simple Python implementation to estimate ozone released from major roadways in the Salt Lake City valley. The example uses a coarse 3D grid and simple advection/diffusion scheme.  Geographic data for the major roads are loaded from a shapefile using ``geopandas`` and ``matplotlib`` is used for plotting.
 
 ## Files
 
 - `ozone_model.py` – minimal ozone transport model.
-- `simulate.py` – runs a 24‑hour example simulation with basic road sources.
+- `visualization.py` – helpers to load road data and render maps.
+- `simulate.py` – runs a 24‑hour example simulation with road sources from ``slc_roads.shp``.
 
 ## Running the example
 

--- a/ozone_model.py
+++ b/ozone_model.py
@@ -9,6 +9,7 @@ class RoadSource:
     start: Tuple[float, float]
     end: Tuple[float, float]
     rate_func: Callable[[float], float]
+    name: str = ""
 
     def cells(self, dx: float, dy: float) -> List[Tuple[int, int]]:
         """Return grid cells along the road"""

--- a/simulate.py
+++ b/simulate.py
@@ -1,4 +1,6 @@
 from ozone_model import OzoneModel, RoadSource
+from visualization import plot_valley_map
+import matplotlib.pyplot as plt
 
 # Boundaries for SLC area (arbitrary units)
 # north_south: 0 at north (2300 N) to 16900 at south (14600 S)
@@ -17,15 +19,23 @@ def rush_hour_rate(t: float) -> float:
     return 1.0
 
 # Add major roads (simplified as straight lines)
-# I-15 runs north-south through center of valley
-model.add_road_source(RoadSource(start=(0, 10000), end=(16900, 10000), rate_func=rush_hour_rate))
-# I-215 partial loop (approx)
-model.add_road_source(RoadSource(start=(5000, 18000), end=(15000, 18000), rate_func=rush_hour_rate))
-# I-80 east-west
-model.add_road_source(RoadSource(start=(8000, 0), end=(8000, 20000), rate_func=rush_hour_rate))
+roads = [
+    # I-15 runs north-south through center of valley
+    RoadSource(start=(0, 10000), end=(16900, 10000), rate_func=rush_hour_rate, name="I-15"),
+    # I-215 partial loop (approx)
+    RoadSource(start=(5000, 18000), end=(15000, 18000), rate_func=rush_hour_rate, name="I-215"),
+    # I-80 east-west
+    RoadSource(start=(8000, 0), end=(8000, 20000), rate_func=rush_hour_rate, name="I-80"),
+]
+
+for road in roads:
+    model.add_road_source(road)
 
 # Simple simulation
 if __name__ == "__main__":
+    fig, _ = plot_valley_map(model.north_south, model.west_east, roads)
+    fig.savefig("slc_valley_map.png")
+    plt.close(fig)
     steps = 24
     dt = 1.0  # hour
     for s in range(steps):

--- a/simulate.py
+++ b/simulate.py
@@ -1,16 +1,14 @@
-from ozone_model import OzoneModel, RoadSource
-from visualization import plot_valley_map
 import matplotlib.pyplot as plt
 
-# Boundaries for SLC area (arbitrary units)
-# north_south: 0 at north (2300 N) to 16900 at south (14600 S)
-# west_east: 0 at west (Route 85) to 20000 at east (Wasatch)
-model = OzoneModel(north_south=(0, 16900), west_east=(0, 20000))
+from ozone_model import OzoneModel
+from visualization import load_roads, plot_valley_map
 
-# Example emission rate functions
+
+SHAPEFILE = "slc_roads.shp"
+
 
 def rush_hour_rate(t: float) -> float:
-    """Higher emission during rush hour (7-9am, 4-6pm)"""
+    """Higher emission during rush hour (7-9am, 4-6pm)."""
     hour = t % 24
     if 7 <= hour < 9 or 16 <= hour < 18:
         return 5.0
@@ -18,24 +16,19 @@ def rush_hour_rate(t: float) -> float:
         return 0.5
     return 1.0
 
-# Add major roads (simplified as straight lines)
-roads = [
-    # I-15 runs north-south through center of valley
-    RoadSource(start=(0, 10000), end=(16900, 10000), rate_func=rush_hour_rate, name="I-15"),
-    # I-215 partial loop (approx)
-    RoadSource(start=(5000, 18000), end=(15000, 18000), rate_func=rush_hour_rate, name="I-215"),
-    # I-80 east-west
-    RoadSource(start=(8000, 0), end=(8000, 20000), rate_func=rush_hour_rate, name="I-80"),
-]
+
+roads, north_south, west_east, gdf = load_roads(SHAPEFILE, rush_hour_rate)
+model = OzoneModel(north_south=north_south, west_east=west_east)
 
 for road in roads:
     model.add_road_source(road)
 
-# Simple simulation
+
 if __name__ == "__main__":
-    fig, _ = plot_valley_map(model.north_south, model.west_east, roads)
+    fig, _ = plot_valley_map(gdf)
     fig.savefig("slc_valley_map.png")
     plt.close(fig)
+
     steps = 24
     dt = 1.0  # hour
     for s in range(steps):

--- a/visualization.py
+++ b/visualization.py
@@ -1,26 +1,88 @@
+"""Utilities for visualizing the simulation using geographic data."""
+
+from typing import Callable, Iterable, List, Tuple
+
+import geopandas as gpd
 import matplotlib.pyplot as plt
-from typing import Iterable
+
+from ozone_model import RoadSource
 
 
-def plot_valley_map(north_south: tuple, west_east: tuple, roads: Iterable):
-    """Create a basic map of the valley with major roadways."""
+def load_roads(
+    shapefile_path: str, rate_func: Callable[[float], float]
+) -> Tuple[List[RoadSource], Tuple[float, float], Tuple[float, float], gpd.GeoDataFrame]:
+    """Read road centerlines from ``shapefile_path``.
+
+    Returns the generated :class:`RoadSource` objects, the domain bounds as
+    ``(north_south, west_east)`` tuples, and the underlying
+    :class:`geopandas.GeoDataFrame` for mapping purposes.
+    """
+
+    gdf = gpd.read_file(shapefile_path)
+    roads: List[RoadSource] = []
+    for _, row in gdf.iterrows():
+        geom = row.geometry
+        if geom.is_empty:
+            continue
+        name = row.get("name") or row.get("NAME") or ""
+
+        def _add_segment(coords):
+            roads.append(
+                RoadSource(
+                    start=(coords[0][1], coords[0][0]),
+                    end=(coords[-1][1], coords[-1][0]),
+                    rate_func=rate_func,
+                    name=name,
+                )
+            )
+
+        if geom.geom_type == "LineString":
+            coords = list(geom.coords)
+            _add_segment(coords)
+        elif geom.geom_type == "MultiLineString":
+            for line in geom.geoms:
+                coords = list(line.coords)
+                _add_segment(coords)
+
+    minx, miny, maxx, maxy = gdf.total_bounds
+    north_south = (miny, maxy)
+    west_east = (minx, maxx)
+    return roads, north_south, west_east, gdf
+
+
+def plot_valley_map(gdf: gpd.GeoDataFrame):
+    """Plot roads from ``gdf`` on a map of the Salt Lake City valley."""
+
     fig, ax = plt.subplots(figsize=(8, 8))
-    ax.set_xlim(west_east)
-    ax.set_ylim(north_south)
+    gdf.plot(ax=ax, color="black", linewidth=0.5)
+
     ax.set_xlabel("West-East (m)")
     ax.set_ylabel("North-South (m)")
     ax.set_title("Salt Lake City Valley")
 
-    for road in roads:
-        x0, y0 = road.start
-        x1, y1 = road.end
-        xs = [y0, y1]
-        ys = [x0, x1]
-        ax.plot(xs, ys, color="black")
-        name = getattr(road, "name", "")
-        if name:
-            mx = sum(xs) / 2
-            my = sum(ys) / 2
-            ax.text(mx, my, name, ha="center", va="center", fontsize=8, backgroundcolor="white")
+    name_field = None
+    for candidate in ("name", "NAME", "Name"):
+        if candidate in gdf.columns:
+            name_field = candidate
+            break
 
+    if name_field:
+        for _, row in gdf.iterrows():
+            label = row[name_field]
+            if not label:
+                continue
+            # Place label near the middle of the line
+            pt = row.geometry.interpolate(0.5, normalized=True).coords[0]
+            ax.text(
+                pt[0],
+                pt[1],
+                label,
+                ha="center",
+                va="center",
+                fontsize=6,
+                backgroundcolor="white",
+            )
+
+    ax.set_xlim(gdf.total_bounds[[0, 2]])
+    ax.set_ylim(gdf.total_bounds[[1, 3]])
     return fig, ax

--- a/visualization.py
+++ b/visualization.py
@@ -1,0 +1,26 @@
+import matplotlib.pyplot as plt
+from typing import Iterable
+
+
+def plot_valley_map(north_south: tuple, west_east: tuple, roads: Iterable):
+    """Create a basic map of the valley with major roadways."""
+    fig, ax = plt.subplots(figsize=(8, 8))
+    ax.set_xlim(west_east)
+    ax.set_ylim(north_south)
+    ax.set_xlabel("West-East (m)")
+    ax.set_ylabel("North-South (m)")
+    ax.set_title("Salt Lake City Valley")
+
+    for road in roads:
+        x0, y0 = road.start
+        x1, y1 = road.end
+        xs = [y0, y1]
+        ys = [x0, x1]
+        ax.plot(xs, ys, color="black")
+        name = getattr(road, "name", "")
+        if name:
+            mx = sum(xs) / 2
+            my = sum(ys) / 2
+            ax.text(mx, my, name, ha="center", va="center", fontsize=8, backgroundcolor="white")
+
+    return fig, ax


### PR DESCRIPTION
## Summary
- add plotting utility to render the Salt Lake City valley and major roads
- extend `RoadSource` with optional name for labeling
- generate a base map image when running the simulator

## Testing
- `python simulate.py` *(fails: ModuleNotFoundError: No module named 'matplotlib')*
- `pip install matplotlib` *(fails: Could not find a version that satisfies the requirement matplotlib: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e3c4cee8832896c732f27a0c00ee